### PR TITLE
Fix Docker build

### DIFF
--- a/deployments/Dockerfile.daemon
+++ b/deployments/Dockerfile.daemon
@@ -7,8 +7,7 @@ ENV IPFS_VERSION v0.10.0
 RUN apt-get update && \
     apt-get install -y build-essential git && \
     git clone --depth 1 --branch $IPFS_VERSION https://github.com/ipfs/go-ipfs.git /go-ipfs && \
-    cd /go-ipfs && make build && \
-    /build/cleanup.sh
+    cd /go-ipfs && make build
 
 COPY cmd/ipfs-daemon /go/cmd/ipfs-daemon
 COPY pkg /go/pkg

--- a/deployments/Dockerfile.monitor
+++ b/deployments/Dockerfile.monitor
@@ -3,8 +3,7 @@ FROM golang:1.17.10-bullseye as builder
 WORKDIR /go
 
 RUN apt-get update && \
-    apt-get install -y build-essential && \
-    /build/cleanup.sh
+    apt-get install -y build-essential
 
 COPY cmd/ipfs-gw-measure /go/cmd/ipfs-gw-measure
 COPY cmd/ipfs-gw-monitor /go/cmd/ipfs-gw-monitor


### PR DESCRIPTION
`golang` images do not have a `/build/cleanup.sh` script. This commit
removes this step.
This does not increase the size of the built image because of the
multistage build.

Closes #1 